### PR TITLE
Adding 'good' and 'bad' Account triggers

### DIFF
--- a/force-app/main/default/classes/AccountTriggerHandler.cls
+++ b/force-app/main/default/classes/AccountTriggerHandler.cls
@@ -1,0 +1,80 @@
+public with sharing class AccountTriggerHandler {
+    
+    public static void handleBeforeInsert(List<Account> newAccounts){
+        for (Account a : newAccounts) {
+            if (a.Est_Annual_Sales__c >= 5000000) {
+                a.Priority__c = 'Highest';
+            } else if (a.Est_Annual_Sales__c >= 3000000) {
+                a.Priority__c = 'High';
+            } else if (a.Est_Annual_Sales__c >= 1000000) {
+                a.Priority__c = 'Standard';
+            } else {
+                a.Priority__c = 'Low';
+            }
+        }
+        //this is a before trigger, so our handler doesn't have to call DML
+    }
+
+    public static void handleAfterInsert(List<Account> newAccounts){
+        
+        Id runningUserId = UserInfo.getUserId();
+        //Week 7 Homework - bulkify this code
+        for (Account a : newAccounts) {
+            Case c = new Case();
+            c.Status = 'New';
+            c.Origin = 'New Account'; //Make sure you've added this as a picklist value for this field
+            c.Subject = 'Send Welcome Package';
+            c.AccountId = a.Id;
+            c.Description = 'Please follow up with this new Account and send them a Welcome Package.';
+
+            //Get the email address for the Account owner
+            User u = [SELECT Id, Email FROM User WHERE Id = :runningUserId];
+            c.Staff_Email_Address__c = u.Email;
+            insert c;
+        }
+    }
+
+    public static void handleAfterUpdate(List<Account> acctsForUpdate, Map<Id, Account> oldAcctMap){
+        //First thing we do is query for all the opportunities on accounts involved in this trigger
+        //The SOQL query below uses a nested query, this let's us pull back each acccount with a list of its opportunities attached.
+        //We won't be covering nested queries in this class, but take a look and see if you can figure out how they work
+        Map<Id, Account> acctsWithOpps = new Map<Id, Account>(
+            [SELECT Id, (SELECT Id FROM Opportunities WHERE IsClosed = false) FROM Account WHERE Id IN :acctsForUpdate]
+        );
+
+        //Let's make a list to hold any opportunities we create for later insertion
+        List<Opportunity> newOpportunities = new List<Opportunity>();
+
+        //Now we need to loop through the accounts in this trigger and see if their priority has been changed in the way we're looking for
+        for (Account updatedAcct : acctsForUpdate) {
+
+            //ok, so now we have the udpated Account record, but we also need to compare it to the old version to see what has changed
+            //We can use the oldAccountMap, pass it the Account Id, and we'll get the old version for comparison
+            Account oldAcct = oldAcctMap.get(updatedAcct.Id);
+
+            //ok, now we have the new and old versions of the same record and we can make our comparison
+            if ((oldAcct.Priority__c != 'Highest' && oldAcct.Priority__c != 'High') && (updatedAcct.Priority__c == 'Highest' || updatedAcct.Priority__c == 'High')) {
+                //we have a winner!  now check and see if the account has any Open Opportunities
+
+                System.debug('Number of Opportunities on this Account' + acctsWithOpps.get(updatedAcct.Id).Opportunities.size());
+
+                if (acctsWithOpps.get(updatedAcct.Id).Opportunities.size() == 0) {
+                    //Ok, this account has no open opportunities, let's create one
+                    Opportunity opp = new Opportunity();
+                    opp.Name = updatedAcct.Name + ' Opportunity';
+                    opp.StageName = 'Prospecting';
+                    opp.CloseDate = Date.today().addMonths(3);
+                    opp.AccountId = updatedAcct.Id;
+                    newOpportunities.add(opp);
+                }
+            }
+        }
+
+        //Finally, insert any new Opportunities
+        if (newOpportunities.size() > 0) {
+            insert newOpportunities;
+        }
+
+    }
+
+}

--- a/force-app/main/default/classes/AccountTriggerHandler.cls-meta.xml
+++ b/force-app/main/default/classes/AccountTriggerHandler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="AccountTriggerHandler">
+    <apiVersion>45.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/triggers/AccountTriggerBad.trigger
+++ b/force-app/main/default/triggers/AccountTriggerBad.trigger
@@ -1,8 +1,10 @@
-//The first line of our trigger gives the Trigger's name (AccountTrigger), names the object (Account) and lists the trigger_events that will cause the code below to execute
-//For example, "before insert" indicates that before an account record (or records) is inserted,  the trigger will be called.
+//We're calling this 'BadAccountTrigger' because this trigger has business logic directly coded in the trigger file. It's also using
+//way more parameters (on line 6) than it actually uses in the trigger itself. Both of these are considered bad practice. 
+//Business logic coded directly in a trigger and having extra stuff in your code both make the code hard to read and hard to maintain.  
+//The 'GoodAccountTrigger' shows how to use a handler class with your trigger and is much simpler to read. 
 //For more information on trigger syntax: https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_triggers_syntax.htm
 
-trigger AccountTrigger on Account (before insert, before update, before delete, after insert, after update, after delete, after undelete) {
+trigger AccountTriggerBad on Account (before insert, before update, before delete, after insert, after update, after delete, after undelete) {
 
     //Each section of code below handles a different event & timing combination.  For now, we are demonstrating a trigger that has all of the logic right here.
     //Later on we'll be looking at other ways of handling Trigger events using handler classes, but for now, we want to keep all the logic in once place as

--- a/force-app/main/default/triggers/AccountTriggerBad.trigger-meta.xml
+++ b/force-app/main/default/triggers/AccountTriggerBad.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>31.0</apiVersion>
+    <apiVersion>45.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/AccountTriggerGood.trigger
+++ b/force-app/main/default/triggers/AccountTriggerGood.trigger
@@ -1,0 +1,25 @@
+//This is a better example of a trigger. It uses a trigger handler to carry out business logic,
+//and it only accepts parameters that have related trigger handlers. It also doesn't have unused if/else statements.
+//As a developer works on this trigger in the future, they can easily see when they're writing new trigger logic, or expanding
+//on existing logic because the trigger is readable and doesn't have unsued code just hanging out.
+
+trigger AccountTriggerGood on Account (before insert, before update, after insert, after update) {
+    
+    // First, we have a simpler if/else if block separating inserts from updates 
+    // This helps trigger performance and keeps triggers with lots of handlers more readable
+    if (Trigger.isInsert) {
+        if(Trigger.isBefore){
+             AccountTriggerHandler.handleBeforeInsert(Trigger.new);
+        } else if(Trigger.isAfter){
+             AccountTriggerHandler.handleAfterInsert(Trigger.new);
+        }
+        
+    } else if (Trigger.isUpdate){
+        //we don't have any business logic for before updates, so we don't need to have an unused if statement
+        if(Trigger.isAfter){
+             AccountTriggerHandler.handleAfterUpdate(Trigger.new, Trigger.oldMap);
+        }
+    }
+    //future trigger logic blocks here
+
+}

--- a/force-app/main/default/triggers/AccountTriggerGood.trigger
+++ b/force-app/main/default/triggers/AccountTriggerGood.trigger
@@ -9,15 +9,15 @@ trigger AccountTriggerGood on Account (before insert, before update, after inser
     // This helps trigger performance and keeps triggers with lots of handlers more readable
     if (Trigger.isInsert) {
         if(Trigger.isBefore){
-             AccountTriggerHandler.handleBeforeInsert(Trigger.new);
+            // AccountTriggerHandler.handleBeforeInsert(Trigger.new);
         } else if(Trigger.isAfter){
-             AccountTriggerHandler.handleAfterInsert(Trigger.new);
+            // AccountTriggerHandler.handleAfterInsert(Trigger.new);
         }
         
     } else if (Trigger.isUpdate){
         //we don't have any business logic for before updates, so we don't need to have an unused if statement
         if(Trigger.isAfter){
-             AccountTriggerHandler.handleAfterUpdate(Trigger.new, Trigger.oldMap);
+            // AccountTriggerHandler.handleAfterUpdate(Trigger.new, Trigger.oldMap);
         }
     }
     //future trigger logic blocks here

--- a/force-app/main/default/triggers/AccountTriggerGood.trigger-meta.xml
+++ b/force-app/main/default/triggers/AccountTriggerGood.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata" fqn="GoodAccountTrigger">
+  <apiVersion>45.0</apiVersion>
+  <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
I duplicated the Account trigger into 2: 'Good' and 'Bad' examples. The 'good' trigger is currently commented out so the 2 triggers don't cause chaos in the app. Learners can either deactivate the 'bad' trigger and uncomment the good to activate, or comment out the bad trigger (which might be hard with all the in-line comments). I thought having the same code displayed directly in the trigger and then in a handler pattern might make it easier to track what's happening, as an intro to handlers.