### PR TITLE
update apiVersion for all metadata

### DIFF
--- a/force-app/main/default/classes/AccountTriggerHandler.cls-meta.xml
+++ b/force-app/main/default/classes/AccountTriggerHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/AccountTriggerHandlerTest.cls-meta.xml
+++ b/force-app/main/default/classes/AccountTriggerHandlerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>52.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/Calculator.cls-meta.xml
+++ b/force-app/main/default/classes/Calculator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CommentingOnCodeExercise.cls-meta.xml
+++ b/force-app/main/default/classes/CommentingOnCodeExercise.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CompletedStockHandler.cls-meta.xml
+++ b/force-app/main/default/classes/CompletedStockHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/CompletedStockItem.cls-meta.xml
+++ b/force-app/main/default/classes/CompletedStockItem.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ContactHandler_Test.cls-meta.xml
+++ b/force-app/main/default/classes/ContactHandler_Test.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ContactTriggerHandler.cls-meta.xml
+++ b/force-app/main/default/classes/ContactTriggerHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ContactTriggerHandlerV2.cls-meta.xml
+++ b/force-app/main/default/classes/ContactTriggerHandlerV2.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ContactTriggerHandlerV3.cls-meta.xml
+++ b/force-app/main/default/classes/ContactTriggerHandlerV3.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/FibonacciList.cls-meta.xml
+++ b/force-app/main/default/classes/FibonacciList.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/Item.cls-meta.xml
+++ b/force-app/main/default/classes/Item.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ItemCollection.cls-meta.xml
+++ b/force-app/main/default/classes/ItemCollection.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/PackageCoverageTests.cls-meta.xml
+++ b/force-app/main/default/classes/PackageCoverageTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/Part2SOQLExercises.cls-meta.xml
+++ b/force-app/main/default/classes/Part2SOQLExercises.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/RadException.cls-meta.xml
+++ b/force-app/main/default/classes/RadException.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ShoppingCart.cls-meta.xml
+++ b/force-app/main/default/classes/ShoppingCart.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/StockItem.cls-meta.xml
+++ b/force-app/main/default/classes/StockItem.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/StockItemHandler.cls-meta.xml
+++ b/force-app/main/default/classes/StockItemHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/StockItemHandler_Test.cls-meta.xml
+++ b/force-app/main/default/classes/StockItemHandler_Test.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/WeekEightHomework.cls-meta.xml
+++ b/force-app/main/default/classes/WeekEightHomework.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/WeekFiveClassExercises.cls-meta.xml
+++ b/force-app/main/default/classes/WeekFiveClassExercises.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/WeekFiveHomework.cls-meta.xml
+++ b/force-app/main/default/classes/WeekFiveHomework.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/WeekFourClassExercises.cls-meta.xml
+++ b/force-app/main/default/classes/WeekFourClassExercises.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/WeekFourHomework.cls-meta.xml
+++ b/force-app/main/default/classes/WeekFourHomework.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/WeekOneClassExercises.cls-meta.xml
+++ b/force-app/main/default/classes/WeekOneClassExercises.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/WeekOneHomework.cls-meta.xml
+++ b/force-app/main/default/classes/WeekOneHomework.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/WeekSevenClassExercises.cls-meta.xml
+++ b/force-app/main/default/classes/WeekSevenClassExercises.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/WeekSevenHomework.cls-meta.xml
+++ b/force-app/main/default/classes/WeekSevenHomework.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/WeekSixClassExercises.cls-meta.xml
+++ b/force-app/main/default/classes/WeekSixClassExercises.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/WeekSixHomework.cls-meta.xml
+++ b/force-app/main/default/classes/WeekSixHomework.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/WeekThreeClassExercises.cls-meta.xml
+++ b/force-app/main/default/classes/WeekThreeClassExercises.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/WeekThreeHomework.cls-meta.xml
+++ b/force-app/main/default/classes/WeekThreeHomework.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/WeekTwoClassExercises.cls-meta.xml
+++ b/force-app/main/default/classes/WeekTwoClassExercises.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/WeekTwoHomework.cls-meta.xml
+++ b/force-app/main/default/classes/WeekTwoHomework.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/Welcome.cls-meta.xml
+++ b/force-app/main/default/classes/Welcome.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/myControllerExtension.cls-meta.xml
+++ b/force-app/main/default/classes/myControllerExtension.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/packageTestCoverage.cls-meta.xml
+++ b/force-app/main/default/classes/packageTestCoverage.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/pages/SampleAccountForm.page-meta.xml
+++ b/force-app/main/default/pages/SampleAccountForm.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <description>Sample Visualforce Page</description>

--- a/force-app/main/default/pages/SampleControllerExtensionPage.page-meta.xml
+++ b/force-app/main/default/pages/SampleControllerExtensionPage.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>SampleControllerExtensionPage</label>

--- a/force-app/main/default/triggers/AccountTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/AccountTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-  <apiVersion>52.0</apiVersion>
+  <apiVersion>65.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/CompletedStockItemTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/CompletedStockItemTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/ContactTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/ContactTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/ContactTriggerV3.trigger-meta.xml
+++ b/force-app/main/default/triggers/ContactTriggerV3.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/OpportunityTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/OpportunityTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/force-app/main/default/triggers/StockItemTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/StockItemTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>65.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>


### PR DESCRIPTION
most of the metadata is currently v45, which is likely going to be deprecated soon (as it is currently the lowest supported API version, and current is 20+ versions ahead). This should get us current.